### PR TITLE
202 classid of student should not be part of student creation backend

### DIFF
--- a/serverside/dto/createStudentDto.ts
+++ b/serverside/dto/createStudentDto.ts
@@ -33,8 +33,4 @@ export class CreateStudentDto {
   @IsNotEmpty()
   @IsString()
   readonly lastname: string;
-
-  @IsNotEmpty()
-  @IsNumber()
-  readonly classID: number;
 }

--- a/serverside/src/auth/users/users.service.ts
+++ b/serverside/src/auth/users/users.service.ts
@@ -8,9 +8,6 @@ export class UsersService {
     newStudent: CreateStudentDto,
     prisma: PrismaClient,
   ): Promise<Student> {
-    // first check if class exists
-    await this.checkClass(newStudent.classID, prisma);
-
     // create login data
     const createdLoginData: User_Login_Data = await this.createLoginData(
       newStudent.user_Login_Data,
@@ -21,10 +18,11 @@ export class UsersService {
     // create student
     const createdStudent: Student = await prisma.student.create({
       data: {
-        user_Login_DataUser_Login_DataID: user_Login_Data_ID,
+        User_Login_Data: {
+          connect: { user_Login_DataID: user_Login_Data_ID },
+        },
         name: newStudent.name,
         lastname: newStudent.lastname,
-        classClassID: newStudent.classID,
       },
     });
 
@@ -48,20 +46,6 @@ export class UsersService {
       throw new HttpException(
         'user with email ' + newData.email + ' already exists!',
         HttpStatus.CONFLICT,
-      );
-    }
-  }
-  async checkClass(classID: number, prisma: PrismaClient) {
-    const classCount = await prisma.class.count({
-      where: {
-        classID: classID,
-      },
-    });
-    // if no class exists with the ID, throw exception
-    if (classCount == 0) {
-      throw new HttpException(
-        'class with ID: ' + classID + ' does not exist',
-        HttpStatus.NOT_FOUND,
       );
     }
   }

--- a/serverside/tests/auth/users/users.controller.spec.ts
+++ b/serverside/tests/auth/users/users.controller.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UsersController } from '../../../src/auth/users/users.controller';
 import { HttpException, HttpStatus, INestApplication } from '@nestjs/common';
 import { UsersService } from '../../../src/auth/users/users.service';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Student } from '@prisma/client';
 import {
   CreateStudentDto,
   User_Login_DataDto,
@@ -20,7 +20,6 @@ describe('UsersController', () => {
     user_Login_Data: mockLoginData,
     name: 'Test',
     lastname: 'Student',
-    classID: 1,
   };
 
   beforeEach(async () => {
@@ -49,7 +48,7 @@ describe('UsersController', () => {
     //mock role
     const mockRole = 'Admin';
     //mock return value
-    const mockReturnStudent = {
+    const mockReturnStudent: Student = {
       studentID: 1,
       user_Login_DataUser_Login_DataID: 1,
       name: 'mock',
@@ -59,7 +58,7 @@ describe('UsersController', () => {
     const createUserSpy = jest
       .spyOn(controller['userService'], 'createUser')
       .mockResolvedValueOnce(mockReturnStudent);
-    //
+
     const result = await controller.createStudent(mockRole, mockStudent);
 
     // check if result is as expected

--- a/serverside/tests/auth/users/users.service.spec.ts
+++ b/serverside/tests/auth/users/users.service.spec.ts
@@ -19,7 +19,6 @@ describe('UsersService', () => {
     user_Login_Data: mockLoginData,
     name: 'Test',
     lastname: 'Student',
-    classID: 1,
   };
 
   beforeEach(async () => {
@@ -55,10 +54,7 @@ describe('UsersService', () => {
   });
   describe('tests for createUser function', () => {
     it('should create a user with valid input', async () => {
-      // mock result of checkClass and createLoginData
-      const checkCLassSpy = jest
-        .spyOn(service, 'checkClass')
-        .mockResolvedValueOnce(undefined);
+      // mock result of  createLoginData
       const createLoginDataSyp = jest
         .spyOn(service, 'createLoginData')
         .mockResolvedValueOnce({
@@ -87,18 +83,19 @@ describe('UsersService', () => {
       expect(result).toEqual(mockCreatedStudent);
 
       // check if all functions have been called correctly
-      expect(checkCLassSpy).toHaveBeenCalledWith(mockStudent.classID, prisma);
       expect(createLoginDataSyp).toHaveBeenCalledWith(
         mockStudent.user_Login_Data,
         prisma,
       );
       expect(createStudentMock).toHaveBeenCalledWith({
         data: {
-          user_Login_DataUser_Login_DataID:
-            mockCreatedStudent.user_Login_DataUser_Login_DataID,
+          User_Login_Data: {
+            connect: {
+              user_Login_DataID: 1234,
+            },
+          },
           name: mockStudent.name,
           lastname: mockStudent.lastname,
-          classClassID: mockStudent.classID,
         },
       });
     });
@@ -157,51 +154,6 @@ describe('UsersService', () => {
           email: mockLoginData.email,
           password: mockLoginData.password,
           role: 'Student',
-        },
-      });
-    });
-  });
-  describe('tests for check class function', () => {
-    it('should not throw exception when class exists', async () => {
-      // mock classID
-      const mockClass = 1;
-
-      //mock class count
-      const classCountMock = jest.spyOn(prisma.class, 'count');
-      classCountMock.mockResolvedValueOnce(1);
-
-      // call method
-      await expect(
-        service.checkClass(mockClass, prisma),
-      ).resolves.not.toThrow();
-
-      // check if prisma clount has been called correctly
-      expect(classCountMock).toHaveBeenCalledWith({
-        where: {
-          classID: mockClass,
-        },
-      });
-    });
-    it('should throw exception', async () => {
-      // mock classID
-      const mockClass = 1;
-
-      // mock class count to return 0
-      const classCountMock = jest.spyOn(prisma.class, 'count');
-      classCountMock.mockResolvedValueOnce(0);
-
-      // call method and expect it to throw exception
-      await expect(service.checkClass(mockClass, prisma)).rejects.toThrowError(
-        new HttpException(
-          'class with ID: ' + mockClass + ' does not exist',
-          HttpStatus.NOT_FOUND,
-        ),
-      );
-
-      // check if prisma count has been called correctly
-      expect(classCountMock).toHaveBeenCalledWith({
-        where: {
-          classID: mockClass,
         },
       });
     });


### PR DESCRIPTION
### Beschreibung der Änderungen
- classID ist nicht mehr mandatory, um erst students und dann classes createn zu können
- tests wurden entfernt
### Issue

### Checklist

- [x] Ich habe meinen code selber überprüft
- [x] Das Projekt kann ohne Probleme gestartet werden
- [x] Ich habe Tests geschrieben, falls das Issue ein Core Feature ist.
- [x] Ich habe meine Funktionen für die Verständlichkeit anderer mit Kommentaren ausgestattet
- [x] Ich habe den code gelinted (´npm run lint´)
