### PR TITLE
115 stundenplan backend

### DIFF
--- a/serverside/package-lock.json
+++ b/serverside/package-lock.json
@@ -19,6 +19,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "dotenv-cli": "^7.3.0",
+        "moment": "^2.30.1",
         "nestjs-prisma": "^0.23.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1"
@@ -6659,6 +6660,14 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/serverside/package.json
+++ b/serverside/package.json
@@ -34,6 +34,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "dotenv-cli": "^7.3.0",
+    "moment": "^2.30.1",
     "nestjs-prisma": "^0.23.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1"

--- a/serverside/src/lesson/lesson.controller.ts
+++ b/serverside/src/lesson/lesson.controller.ts
@@ -1,6 +1,16 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Headers } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { Get, Param } from '@nestjs/common';
 
 @ApiTags('Lesson')
 @Controller('lesson')
-export class LessonController {}
+export class LessonController {
+  @Get(':classId/week/:weekNumber')
+  getAllLessonsForClassInWeek(
+    @Headers('role') role,
+    @Param('classID') classId: number,
+    @Param('weekStart') weekNumber: number,
+  ) {
+    // Your code to fetch all lessons for a certain class in a week goes here
+  }
+}

--- a/serverside/src/lesson/lesson.controller.ts
+++ b/serverside/src/lesson/lesson.controller.ts
@@ -1,16 +1,28 @@
-import { Controller, Headers } from '@nestjs/common';
+import { Controller, Inject, ParseIntPipe } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Get, Param } from '@nestjs/common';
+import { LessonService } from './lesson.service';
+import { Prisma, PrismaClient } from '@prisma/client';
 
 @ApiTags('Lesson')
 @Controller('lesson')
 export class LessonController {
-  @Get(':classId/week/:weekNumber')
-  getAllLessonsForClassInWeek(
-    @Headers('role') role,
-    @Param('classID') classId: number,
-    @Param('weekStart') weekNumber: number,
+  constructor(
+    private readonly lessonService: LessonService,
+    @Inject('PRISMA') private prisma: PrismaClient<Prisma.PrismaClientOptions>,
+  ) {}
+
+  @Get('getLessonsForWeek/:weekStart/:classId')
+  async getLessonsForWeek(
+    //@Headers('role') role,
+    @Param('weekStart') weekStart: Date,
+    @Param('classID', new ParseIntPipe()) classID: number,
   ) {
-    // Your code to fetch all lessons for a certain class in a week goes here
+    //keine Rolle abfragen, da jeder den Stundenplan betrachten kann
+    return await this.lessonService.getLessonsForWeek(
+      weekStart,
+      classID,
+      this.prisma,
+    );
   }
 }

--- a/serverside/src/lesson/lesson.module.ts
+++ b/serverside/src/lesson/lesson.module.ts
@@ -1,7 +1,16 @@
 import { Module } from '@nestjs/common';
 import { LessonController } from './lesson.controller';
+import { LessonService } from './lesson.service';
+import { PrismaClient } from '@prisma/client';
 
 @Module({
+  providers: [
+    LessonService,
+    {
+      provide: 'PRISMA',
+      useValue: new PrismaClient(),
+    },
+  ],
   controllers: [LessonController],
 })
 export class LessonModule {}

--- a/serverside/src/lesson/lesson.service.ts
+++ b/serverside/src/lesson/lesson.service.ts
@@ -1,4 +1,20 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaClient, Lesson } from '@prisma/client';
+import moment from 'moment';
 
 @Injectable()
-export class LessonService {}
+export class LessonService {
+  async getLessonsForWeek(classID: number, weekStart: string, prisma: PrismaClient) : Promise<Lesson[]> {
+    const lessons: Lesson[] = await prisma.lesson.findMany({
+      where: {
+        classClassID: classID,
+        startTime : {
+          gte: new Date(weekStart),
+          lt: moment(weekStart).add(5, 'days').toDate(),
+        }
+      }
+    });
+    return lessons
+  }
+
+}

--- a/serverside/src/lesson/lesson.service.ts
+++ b/serverside/src/lesson/lesson.service.ts
@@ -9,7 +9,8 @@ export class LessonService {
     prisma: PrismaClient,
   ): Promise<Lesson[][]> {
     const endOfWeek = new Date(weekStart);
-    endOfWeek.setDate(weekStart.getDate() + 5); // Nur Montag bis Freitag, da am Wochenende keine Schule
+    // Nur Montag bis Freitag, da am Wochenende keine Schule
+    endOfWeek.setDate(weekStart.getDate() + 5);
 
     const lessons: Lesson[] = await prisma.lesson.findMany({
       where: {
@@ -21,18 +22,25 @@ export class LessonService {
       },
     });
 
-    const lessonsByDay: Lesson[][] = [[], [], [], [], []];
-
-    for (const lesson of lessons) {
-      const dayIndex = this.getDayIndex(lesson.startTime);
-      lessonsByDay[dayIndex].push(lesson);
-    }
-
+    const lessonsByDay = sortLessonsToDates(lessons);
     return lessonsByDay;
   }
+}
 
-  private getDayIndex(date: Date): number {
-    // 0 = Montag, 1 = Dienstag, ..., 4 = Freitag
-    return (date.getDay() + 6) % 7;
+//Funktion um die Stunden den Tagen zuzuordnen
+function sortLessonsToDates(lessons) {
+  const lessonsByDay: Lesson[][] = [[], [], [], [], []];
+
+  for (const lesson of lessons) {
+    const dayIndex = getDayIndex(lesson.startTime);
+    lessonsByDay[dayIndex].push(lesson);
   }
+
+  return lessonsByDay;
+}
+
+//Funktion um den Tag herauszufinden, für welche die Stunden sind
+function getDayIndex(date: Date): number {
+  // 0 = Montag, 1 = Dienstag, ..., 4 = Freitag
+  return (date.getDay() + 6) % 7;
 }

--- a/serverside/tests/lesson/lesson.controller.spec.ts
+++ b/serverside/tests/lesson/lesson.controller.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LessonController } from '../../src/lesson/lesson.controller';
+import { LessonService } from '../../src/lesson/lesson.service';
+import { PrismaClient } from '@prisma/client';
 
 describe('LessonController', () => {
   let controller: LessonController;
@@ -7,6 +9,13 @@ describe('LessonController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [LessonController],
+      providers: [
+        LessonService,
+        {
+          provide: 'PRISMA',
+          useValue: new PrismaClient(),
+        },
+      ],
     }).compile();
 
     controller = module.get<LessonController>(LessonController);
@@ -14,5 +23,28 @@ describe('LessonController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getLessonsForWeek', () => {
+    it('should call getLessonsForWeek in LessonService and return the result', async () => {
+      const mockWeekStart = new Date();
+      const mockClassID = 1;
+
+      const lessonServiceSpy = jest
+        .spyOn(controller['lessonService'], 'getLessonsForWeek')
+        .mockResolvedValue(undefined);
+
+      const result = await controller.getLessonsForWeek(
+        mockWeekStart,
+        mockClassID,
+      );
+
+      expect(result).toBeUndefined;
+      expect(lessonServiceSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/serverside/tests/lesson/lesson.service.spec.ts
+++ b/serverside/tests/lesson/lesson.service.spec.ts
@@ -1,18 +1,112 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LessonService } from '../../src/lesson/lesson.service';
+import { PrismaClient } from '@prisma/client';
 
 describe('LessonService', () => {
   let service: LessonService;
+  let prisma: PrismaClient;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [LessonService],
+      providers: [
+        LessonService,
+        {
+          provide: PrismaClient,
+          useFactory: () => ({
+            lesson: {
+              findMany: jest.fn(),
+            },
+          }),
+        },
+      ],
     }).compile();
 
     service = module.get<LessonService>(LessonService);
+    prisma = module.get<PrismaClient>(PrismaClient);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+  describe('getLessonsForWeek', () => {
+    it('should return lessons for the given week and classID', async () => {
+      const mockWeekStart = new Date('2024-05-20');
+      const mockClassID = 123;
+
+      const mockLessons = [
+        {
+          lessonID: 1,
+          classClassID: 123,
+          timeslot: 1,
+          startTime: new Date('2024-05-20T08:00:00'),
+          subjectSubjectID: 456,
+          testTestID: null,
+          duration: 45,
+        },
+        {
+          lessonID: 2,
+          classClassID: 123,
+          timeslot: 2,
+          startTime: new Date('2024-05-21T08:00:00'),
+          subjectSubjectID: 789,
+          testTestID: null,
+          duration: 45,
+        },
+        {
+          lessonID: 3,
+          classClassID: 123,
+          timeslot: 3,
+          startTime: new Date('2024-05-22T08:00:00'),
+          subjectSubjectID: 101,
+          testTestID: null,
+          duration: 45,
+        },
+        {
+          lessonID: 4,
+          classClassID: 123,
+          timeslot: 4,
+          startTime: new Date('2024-05-23T08:00:00'),
+          subjectSubjectID: 202,
+          testTestID: null,
+          duration: 45,
+        },
+        {
+          lessonID: 5,
+          classClassID: 123,
+          timeslot: 5,
+          startTime: new Date('2024-05-24T08:00:00'),
+          subjectSubjectID: 303,
+          testTestID: null,
+          duration: 45,
+        },
+      ];
+
+      const prismaFindManySpy = jest
+        .spyOn(prisma.lesson, 'findMany')
+        .mockResolvedValue(mockLessons);
+
+      const result = await service.getLessonsForWeek(
+        mockWeekStart,
+        mockClassID,
+        prisma,
+      );
+
+      expect(prismaFindManySpy).toHaveBeenCalledWith({
+        where: {
+          classClassID: mockClassID,
+          startTime: {
+            gte: mockWeekStart,
+            lte: new Date(mockWeekStart.getTime() + 5 * 24 * 60 * 60 * 1000), //Montag bis Freitag
+          },
+        },
+      });
+      //Für jeden Tag eine Stunde, Montag bis Freitag
+      expect(result).toHaveLength(5);
+      expect(result[0]).toHaveLength(1);
+      expect(result[1]).toHaveLength(1);
+      expect(result[2]).toHaveLength(1);
+      expect(result[3]).toHaveLength(1);
+      expect(result[4]).toHaveLength(1);
+    });
   });
 });


### PR DESCRIPTION
### Beschreibung der Änderungen

### Issue
- #115 
### Checklist

- [x] Ich habe meinen code selber überprüft
- [x] Das Projekt kann ohne Probleme gestartet werden
- [x] Ich habe Tests geschrieben, falls das Issue ein Core Feature ist.
- [x] Ich habe meine Funktionen für die Verständlichkeit anderer mit Kommentaren ausgestattet
- [x] Ich habe den code gelinted (´npm run lint´)

### Anmerkungen
Ich habe keine Exceptions implementiert wenn keine Stunden für die Klassen gefunden werden, da es ja auch sein kann, dass sie einfach einen Tag keinen Unterricht haben.
Für die Ausgabe habe ich mich wie folgt entschieden:
- Zwei-Dimensionales Array, erster Index steht für den Wochentag (Mo-Fr) und die Indizes darin sind die einzelnen Stunden.
- bsp: [0].length = 5 heißt, dass sie 5 Stunden am Montag haben.

Zudem habe ich mich darauf festgelegt, dass immer nur Montag bis Freitag abgefragt wird. Samstag und Sonntag finde ich irrelevant.
Und bei einer Anfrage gibt man immer den Montag an -> getLessonsFromWeek(Montag, KlassenID)
