### PR TITLE
115 stunden für eine Woche - updates fürs Frontend

### DIFF
--- a/serverside/src/lesson/lesson.controller.ts
+++ b/serverside/src/lesson/lesson.controller.ts
@@ -4,9 +4,10 @@ import {
   HttpStatus,
   Inject,
   ParseIntPipe,
+  Query,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Get, Param } from '@nestjs/common';
+import { Get } from '@nestjs/common';
 import { LessonService } from './lesson.service';
 import { Prisma, PrismaClient } from '@prisma/client';
 
@@ -18,11 +19,13 @@ export class LessonController {
     @Inject('PRISMA') private prisma: PrismaClient<Prisma.PrismaClientOptions>,
   ) {}
 
-  @Get('getLessonsForWeek/:weekStart/:classId')
+  @Get('getLessonsForWeek')
+  //http://localhost:3000/lesson/getLessonsForWeek?weekStart=2024-06-03T00:00:00.000Z&classId=1
+  //http://localhost:3000/lesson/getLessonsForWeek?classId=1
   async getLessonsForWeek(
     //@Headers('role') role,
-    @Param('weekStart') weekStart: string,
-    @Param('classId', new ParseIntPipe()) classID: number,
+    @Query('weekStart') weekStart: string,
+    @Query('classId', new ParseIntPipe()) classID: number,
   ) {
     const weekStartDate: Date = weekStart ? new Date(weekStart) : new Date();
     if (!classID) {

--- a/serverside/src/lesson/lesson.controller.ts
+++ b/serverside/src/lesson/lesson.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Inject, ParseIntPipe } from '@nestjs/common';
+import {
+  Controller,
+  HttpException,
+  HttpStatus,
+  Inject,
+  ParseIntPipe,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Get, Param } from '@nestjs/common';
 import { LessonService } from './lesson.service';
@@ -18,7 +24,13 @@ export class LessonController {
     @Param('weekStart') weekStart: string,
     @Param('classId', new ParseIntPipe()) classID: number,
   ) {
-    const weekStartDate = new Date(weekStart);
+    const weekStartDate: Date = weekStart ? new Date(weekStart) : new Date();
+    if (!classID) {
+      throw new HttpException(
+        'You cannot ask for a lessonsplan for no class',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
     console.log(typeof weekStart);
     //keine Rolle abfragen, da jeder den Stundenplan betrachten kann
     return await this.lessonService.getLessonsForWeek(

--- a/serverside/src/lesson/lesson.controller.ts
+++ b/serverside/src/lesson/lesson.controller.ts
@@ -20,8 +20,6 @@ export class LessonController {
   ) {}
 
   @Get('getLessonsForWeek')
-  //http://localhost:3000/lesson/getLessonsForWeek?weekStart=2024-06-03T00:00:00.000Z&classId=1
-  //http://localhost:3000/lesson/getLessonsForWeek?classId=1
   async getLessonsForWeek(
     //@Headers('role') role,
     @Query('weekStart') weekStart: string,

--- a/serverside/src/lesson/lesson.controller.ts
+++ b/serverside/src/lesson/lesson.controller.ts
@@ -25,19 +25,27 @@ export class LessonController {
     @Query('weekStart') weekStart: string,
     @Query('classId', new ParseIntPipe()) classID: number,
   ) {
-    const weekStartDate: Date = weekStart ? new Date(weekStart) : new Date();
+    const weekStartDate: Date = this.getMonday(
+      weekStart ? new Date(weekStart) : new Date(),
+    );
+    console.log(weekStartDate);
     if (!classID) {
       throw new HttpException(
         'You cannot ask for a lessonsplan for no class',
         HttpStatus.BAD_REQUEST,
       );
     }
-    console.log(typeof weekStart);
     //keine Rolle abfragen, da jeder den Stundenplan betrachten kann
     return await this.lessonService.getLessonsForWeek(
       weekStartDate,
       classID,
       this.prisma,
     );
+  }
+
+  private getMonday(date: Date): Date {
+    const day = date.getDay();
+    const diff = date.getDate() - day + (day == 0 ? -6 : 1); //index 0 ist Sonntag, 1 Montag
+    return new Date(date.setDate(diff));
   }
 }

--- a/serverside/src/lesson/lesson.service.ts
+++ b/serverside/src/lesson/lesson.service.ts
@@ -13,6 +13,7 @@ export class LessonService {
     endOfWeek.setDate(weekStart.getDate() + 5);
 
     const subjectNames = await getSubjectNames(prisma);
+    const tests = await prisma.test.findMany();
 
     const lessons: Lesson[] = await prisma.lesson.findMany({
       where: {
@@ -24,20 +25,21 @@ export class LessonService {
       },
     });
 
-    const lessonsWithSubjectName = mapLessonsWithSubjectName(
-      lessons,
-      subjectNames,
-    );
+    const lessonsWithSubjectName = mapLessonsUp(lessons, subjectNames, tests);
     const lessonsByDay = sortLessonsToDates(lessonsWithSubjectName);
     return lessonsByDay;
   }
 }
 
-function mapLessonsWithSubjectName(lessons, subjectNames) {
-  return lessons.map((lesson) => ({
-    ...lesson,
-    subjectName: subjectNames[lesson.subjectSubjectID] || 'No name given',
-  }));
+function mapLessonsUp(lessons, subjectNames, tests) {
+  return lessons.map((lesson) => {
+    const subjectName =
+      subjectNames[lesson.subjectSubjectID] || 'No name given';
+    const testName =
+      tests.find((test) => test.testID === lesson.testTestID)?.topic ||
+      'No Test';
+    return { ...lesson, subjectName, testName };
+  });
 }
 //Funktion um die Stunden den Tagen zuzuordnen
 function sortLessonsToDates(lessons) {

--- a/serverside/tests/lesson/lesson.controller.spec.ts
+++ b/serverside/tests/lesson/lesson.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { LessonController } from '../../src/lesson/lesson.controller';
 import { LessonService } from '../../src/lesson/lesson.service';
 import { PrismaClient } from '@prisma/client';
+import { HttpException, HttpStatus } from '@nestjs/common';
 
 describe('LessonController', () => {
   let controller: LessonController;
@@ -45,6 +46,26 @@ describe('LessonController', () => {
 
       expect(result).toBeUndefined;
       expect(lessonServiceSpy).toHaveBeenCalled();
+    });
+    it('should call getLessonsForWeek without weekstart', async () => {
+      const mockClassID = 1;
+
+      const lessonServiceSpy = jest
+        .spyOn(controller['lessonService'], 'getLessonsForWeek')
+        .mockResolvedValue(undefined);
+
+      const result = await controller.getLessonsForWeek(null, mockClassID);
+
+      expect(result).toBeUndefined;
+      expect(lessonServiceSpy).toHaveBeenCalled();
+    });
+    it('should throw getLessonsForWeek without classID', async () => {
+      await expect(controller.getLessonsForWeek(null, null)).rejects.toThrow(
+        new HttpException(
+          'You cannot ask for a lessonsplan for no class',
+          HttpStatus.BAD_REQUEST,
+        ),
+      );
     });
   });
 });

--- a/serverside/tests/lesson/lesson.service.spec.ts
+++ b/serverside/tests/lesson/lesson.service.spec.ts
@@ -16,12 +16,6 @@ describe('LessonService', () => {
             lesson: {
               findMany: jest.fn(),
             },
-            subject: {
-              findMany: jest.fn(),
-            },
-            test: {
-              findMany: jest.fn(),
-            },
           }),
         },
       ],
@@ -39,72 +33,46 @@ describe('LessonService', () => {
       const mockWeekStart = new Date('2024-05-20');
       const mockClassID = 123;
 
-      const mockSubjects = [
-        {
-          subjectID: 1,
-          name: 'Mathe',
-        },
-        {
-          subjectID: 2,
-          name: 'Englisch',
-        },
-        {
-          subjectID: 3,
-          name: 'Deutsch',
-        },
-      ];
-      const mockTests = [
-        {
-          testID: 1,
-          topic: 'Yannis den Popo versohlen',
-        },
-      ];
-
       const mockLessons = [
         {
           lessonID: 1,
           classClassID: 123,
+          day: new Date('2024-05-20'),
           timeslot: 1,
-          startTime: new Date('2024-05-20T08:00:00'),
           subjectSubjectID: 1,
           testTestID: 1,
-          duration: 45,
         },
         {
           lessonID: 2,
           classClassID: 123,
+          day: new Date('2024-05-21'),
           timeslot: 2,
-          startTime: new Date('2024-05-21T08:00:00'),
           subjectSubjectID: 1,
           testTestID: null,
-          duration: 45,
         },
         {
           lessonID: 3,
           classClassID: 123,
+          day: new Date('2024-05-22'),
           timeslot: 3,
-          startTime: new Date('2024-05-22T08:00:00'),
           subjectSubjectID: 2,
           testTestID: null,
-          duration: 45,
         },
         {
           lessonID: 4,
           classClassID: 123,
+          day: new Date('2024-05-23'),
           timeslot: 4,
-          startTime: new Date('2024-05-23T08:00:00'),
           subjectSubjectID: 3,
           testTestID: null,
-          duration: 45,
         },
         {
           lessonID: 5,
           classClassID: 123,
+          day: new Date('2024-05-24'),
           timeslot: 5,
-          startTime: new Date('2024-05-24T08:00:00'),
           subjectSubjectID: 1,
           testTestID: null,
-          duration: 45,
         },
       ];
       const mockVisibleLessons = [
@@ -112,26 +80,15 @@ describe('LessonService', () => {
           lessonID: 1,
           classClassID: 123,
           timeslot: 1,
-          startTime: new Date('2024-05-20T08:00:00'),
+          day: new Date('2024-05-20'),
           subjectSubjectID: 1,
           testTestID: 1,
-          testName: 'Yannis den Popo versohlen',
-          duration: 45,
-          subjectName: 'Mathe',
         },
       ];
 
       const prismaFindManySpy = jest
         .spyOn(prisma.lesson, 'findMany')
         .mockResolvedValue(mockLessons);
-
-      const prismaSubjectFindManySpy = jest
-        .spyOn(prisma.subject, 'findMany')
-        .mockResolvedValue(mockSubjects);
-
-      const prismaTestFindManySpy = jest
-        .spyOn(prisma.test, 'findMany')
-        .mockResolvedValue(mockTests);
 
       const result = await service.getLessonsForWeek(
         mockWeekStart,
@@ -142,14 +99,16 @@ describe('LessonService', () => {
       expect(prismaFindManySpy).toHaveBeenCalledWith({
         where: {
           classClassID: mockClassID,
-          startTime: {
+          day: {
             gte: mockWeekStart,
             lte: new Date(mockWeekStart.getTime() + 5 * 24 * 60 * 60 * 1000), //Montag bis Freitag
           },
         },
+        include: {
+          Subject: true,
+          Test: true,
+        },
       });
-      expect(prismaSubjectFindManySpy).toHaveBeenCalled();
-      expect(prismaTestFindManySpy).toHaveBeenCalled();
       //Für jeden Tag eine Stunde, Montag bis Freitag
       expect(result).toHaveLength(5);
       expect(result[0]).toHaveLength(1);

--- a/serverside/tests/lesson/lesson.service.spec.ts
+++ b/serverside/tests/lesson/lesson.service.spec.ts
@@ -16,6 +16,9 @@ describe('LessonService', () => {
             lesson: {
               findMany: jest.fn(),
             },
+            subject: {
+              findMany: jest.fn(),
+            },
           }),
         },
       ],
@@ -33,13 +36,28 @@ describe('LessonService', () => {
       const mockWeekStart = new Date('2024-05-20');
       const mockClassID = 123;
 
+      const mockSubjects = [
+        {
+          subjectID: 1,
+          name: 'Mathe',
+        },
+        {
+          subjectID: 2,
+          name: 'Englisch',
+        },
+        {
+          subjectID: 3,
+          name: 'Deutsch',
+        },
+      ];
+
       const mockLessons = [
         {
           lessonID: 1,
           classClassID: 123,
           timeslot: 1,
           startTime: new Date('2024-05-20T08:00:00'),
-          subjectSubjectID: 456,
+          subjectSubjectID: 1,
           testTestID: null,
           duration: 45,
         },
@@ -48,7 +66,7 @@ describe('LessonService', () => {
           classClassID: 123,
           timeslot: 2,
           startTime: new Date('2024-05-21T08:00:00'),
-          subjectSubjectID: 789,
+          subjectSubjectID: 1,
           testTestID: null,
           duration: 45,
         },
@@ -57,7 +75,7 @@ describe('LessonService', () => {
           classClassID: 123,
           timeslot: 3,
           startTime: new Date('2024-05-22T08:00:00'),
-          subjectSubjectID: 101,
+          subjectSubjectID: 2,
           testTestID: null,
           duration: 45,
         },
@@ -66,7 +84,7 @@ describe('LessonService', () => {
           classClassID: 123,
           timeslot: 4,
           startTime: new Date('2024-05-23T08:00:00'),
-          subjectSubjectID: 202,
+          subjectSubjectID: 3,
           testTestID: null,
           duration: 45,
         },
@@ -75,15 +93,31 @@ describe('LessonService', () => {
           classClassID: 123,
           timeslot: 5,
           startTime: new Date('2024-05-24T08:00:00'),
-          subjectSubjectID: 303,
+          subjectSubjectID: 1,
           testTestID: null,
           duration: 45,
+        },
+      ];
+      const mockVisibleLessons = [
+        {
+          lessonID: 1,
+          classClassID: 123,
+          timeslot: 1,
+          startTime: new Date('2024-05-20T08:00:00'),
+          subjectSubjectID: 1,
+          testTestID: null,
+          duration: 45,
+          subjectName: 'Mathe',
         },
       ];
 
       const prismaFindManySpy = jest
         .spyOn(prisma.lesson, 'findMany')
         .mockResolvedValue(mockLessons);
+
+      const prismaSubjectFindManySpy = jest
+        .spyOn(prisma.subject, 'findMany')
+        .mockResolvedValue(mockSubjects);
 
       const result = await service.getLessonsForWeek(
         mockWeekStart,
@@ -100,6 +134,7 @@ describe('LessonService', () => {
           },
         },
       });
+      expect(prismaSubjectFindManySpy).toHaveBeenCalled();
       //Für jeden Tag eine Stunde, Montag bis Freitag
       expect(result).toHaveLength(5);
       expect(result[0]).toHaveLength(1);
@@ -107,6 +142,7 @@ describe('LessonService', () => {
       expect(result[2]).toHaveLength(1);
       expect(result[3]).toHaveLength(1);
       expect(result[4]).toHaveLength(1);
+      expect(result[0]).toEqual(mockVisibleLessons);
     });
   });
 });

--- a/serverside/tests/lesson/lesson.service.spec.ts
+++ b/serverside/tests/lesson/lesson.service.spec.ts
@@ -19,6 +19,9 @@ describe('LessonService', () => {
             subject: {
               findMany: jest.fn(),
             },
+            test: {
+              findMany: jest.fn(),
+            },
           }),
         },
       ],
@@ -50,6 +53,12 @@ describe('LessonService', () => {
           name: 'Deutsch',
         },
       ];
+      const mockTests = [
+        {
+          testID: 1,
+          topic: 'Yannis den Popo versohlen',
+        },
+      ];
 
       const mockLessons = [
         {
@@ -58,7 +67,7 @@ describe('LessonService', () => {
           timeslot: 1,
           startTime: new Date('2024-05-20T08:00:00'),
           subjectSubjectID: 1,
-          testTestID: null,
+          testTestID: 1,
           duration: 45,
         },
         {
@@ -105,7 +114,8 @@ describe('LessonService', () => {
           timeslot: 1,
           startTime: new Date('2024-05-20T08:00:00'),
           subjectSubjectID: 1,
-          testTestID: null,
+          testTestID: 1,
+          testName: 'Yannis den Popo versohlen',
           duration: 45,
           subjectName: 'Mathe',
         },
@@ -118,6 +128,10 @@ describe('LessonService', () => {
       const prismaSubjectFindManySpy = jest
         .spyOn(prisma.subject, 'findMany')
         .mockResolvedValue(mockSubjects);
+
+      const prismaTestFindManySpy = jest
+        .spyOn(prisma.test, 'findMany')
+        .mockResolvedValue(mockTests);
 
       const result = await service.getLessonsForWeek(
         mockWeekStart,
@@ -135,6 +149,7 @@ describe('LessonService', () => {
         },
       });
       expect(prismaSubjectFindManySpy).toHaveBeenCalled();
+      expect(prismaTestFindManySpy).toHaveBeenCalled();
       //Für jeden Tag eine Stunde, Montag bis Freitag
       expect(result).toHaveLength(5);
       expect(result[0]).toHaveLength(1);


### PR DESCRIPTION
### Beschreibung der Änderungen
Fürs Frontend war es nicht so super ausgegeben. Wenn es jetzt einen SubjectNamen und/oder Testnamen gibt, dann wird dieser auch mit ans Frontend geschickt.
Außerdem ist der weekstart parameter optional. So könnt ihr bspw verschiedene aufrufe starten:
 http://localhost:3000/lesson/getLessonsForWeek?weekStart=2024-06-03T00:00:00.000Z&classId=1
 http://localhost:3000/lesson/getLessonsForWeek?classId=1
 
 ist mit Insomnia getestet und tests wurden geschrieben
### Issue
- #115 
### Checklist

- [x] Ich habe meinen code selber überprüft
- [x] Das Projekt kann ohne Probleme gestartet werden
- [x] Ich habe Tests geschrieben, falls das Issue ein Core Feature ist.
- [x] Ich habe meine Funktionen für die Verständlichkeit anderer mit Kommentaren ausgestattet
- [x] Ich habe den code gelinted (´npm run lint´)
